### PR TITLE
Fixed delay serial port reading problem

### DIFF
--- a/noolite/noolite.go
+++ b/noolite/noolite.go
@@ -26,7 +26,7 @@ func CreateDevice(portName string) (Device, error) {
 		BaudRate:        9600,
 		DataBits:        8,
 		StopBits:        1,
-		MinimumReadSize: 4,
+		MinimumReadSize: 1,
 	}
 	port, openError := serial.Open(options)
 	if openError != nil {


### PR DESCRIPTION
Sometime events to mqtt server has been arrived with delay (Only after the next event action). I've decreased buffer for reading and it helps me. 